### PR TITLE
Create annotations.md

### DIFF
--- a/annotations.md
+++ b/annotations.md
@@ -1,0 +1,23 @@
+Annotation Name      |Description
+---------------------|---
+/rpc/request/size    |
+/rpc/response/size   |
+/http/method         |
+/http/status_code    |
+/grpc/status         |
+/http/url            |
+/http/host           |
+/ip/v4               |
+/ip/v6               |
+/stacktrace          |
+/http/client_city    |
+/http/client_country |
+/http/client_region  |
+/sql/query_string    |
+/agent_name          |
+/agent_version       |
+kube/cluster_name    |
+kube/namespace_id    |
+kube/pod_id          |
+kube/container_name  |
+kube/service         |


### PR DESCRIPTION
This is a list of standard annotations that Census should support out of the box. This means:

1. Census libraries should attempt to determine appropriate values for these annotations and then attach them to each trace / span
2. Census libraries should use the annotation names supplied in this list rather than creating their own

Custom annotations are of course encouraged, as are vendor-specific ones. This is simply the global list, and thus it applies to all Census clients.