### PR TITLE
Fixed broken links in the Trace API README

### DIFF
--- a/trace/README.md
+++ b/trace/README.md
@@ -3,8 +3,8 @@ This document serves to document the "look and feel" of the open source trace AP
 the key types (classes, structures, etc.) and functions (methods, etc.).
 
 ## Main APIs
-* [Span API]()
-* [TraceConfig API]()
+* [Span API](Span.md)
+* [TraceConfig API](TraceConfig.md)
 
 ## Utils
 * [Sampling logic](https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/Sampling.md)


### PR DESCRIPTION
Span API & TraceConfig API links were broken and merely reloaded the Trace API README