### PR TITLE
Allow any unicode characters in the TagValue

### DIFF
--- a/tags/TagContext.md
+++ b/tags/TagContext.md
@@ -20,8 +20,8 @@ A string or string wrapper, with some restrictions:
 
 ## TagValue
 
-A string or string wrapper with the same restrictions as `TagKey`, except that it
-is allowed to be empty.
+A TagValue can be any unicode string whose size when encoded in UTF-8
+is less than 256 bytes. An empty value is allowed.
 
 ## Serialization
 


### PR DESCRIPTION
Prometheus permits any characters:
https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels

In gRPC propagation, the tags are binary encoded as UTF-8 strings,
so there should be no problem there. For HTTP, we can use mime
encoding.