### PR TITLE
Remove '.' from the tag names in grpc and http specs.

### DIFF
--- a/stats/HTTP.md
+++ b/stats/HTTP.md
@@ -36,10 +36,10 @@ All client metrics should be tagged with the following.
 
 | Tag suffix         | Description                                                                                              |
 |--------------------|----------------------------------------------------------------------------------------------------------|
-| http.client_method | HTTP method, capitalized (i.e. GET, POST, PUT, DELETE, etc.)                                             |
-| http.client_path   | URL path (not including query string)                                                                    |
-| http.client_status | HTTP status code as an integer (e.g. 200, 404, 500.), or "error" if no response status line was received |
-| http.client_host   | Value of the request Host header                                                                         |
+| http_client_method | HTTP method, capitalized (i.e. GET, POST, PUT, DELETE, etc.)                                             |
+| http_client_path   | URL path (not including query string)                                                                    |
+| http_client_status | HTTP status code as an integer (e.g. 200, 404, 500.), or "error" if no response status line was received |
+| http_client_host   | Value of the request Host header                                                                         |
 
 ### Default views
 
@@ -74,10 +74,10 @@ All server metrics should be tagged with the following.
 
 | Tag suffix         | Description                                                         |
 |--------------------|---------------------------------------------------------------------|
-| http.server_method | HTTP method, capitalized (i.e. GET, POST, PUT, DELETE, etc.)        |
-| http.server_path   | URL path (not including query string)                               |
-| http.server_status | HTTP server status code returned, as an integer e.g. 200, 404, 500. |
-| http.server_host   | Value of the request Host header                                    |
+| http_server_method | HTTP method, capitalized (i.e. GET, POST, PUT, DELETE, etc.)        |
+| http_server_path   | URL path (not including query string)                               |
+| http_server_status | HTTP server status code returned, as an integer e.g. 200, 404, 500. |
+| http_server_host   | Value of the request Host header                                    |
 
 ### Default views
 

--- a/stats/HTTP.md
+++ b/stats/HTTP.md
@@ -69,8 +69,8 @@ Server stats are recorded for each individual HTTP request, including for each r
 ### Tags
 
 All server metrics should be tagged with the following. 
-`http.server_method`, `http.server_path`, `http.server_host` are available in the context for the entire request processing.
-`http.server_status` is only available around the stats recorded at the end of request processing.
+`http_server_method`, `http_server_path`, `http_server_host` are available in the context for the entire request processing.
+`http_server_status` is only available around the stats recorded at the end of request processing.
 
 | Tag suffix         | Description                                                         |
 |--------------------|---------------------------------------------------------------------|

--- a/stats/gRPC.md
+++ b/stats/gRPC.md
@@ -89,8 +89,8 @@ All server metrics should be tagged with the following.
 | grpc_server_method | Full gRPC method name, including package, service and method, e.g. com.exampleapi.v4.BookshelfService/Checkout |
 | grpc_server_status | gRPC server status code returned, e.g. OK, CANCELLED, DEADLINE_EXCEEDED                                        |
 
-`grpc.server_method` is available in the context for the entire RPC call handling. 
-`grpc.server_status` is only available around metrics recorded at the end of the request.
+`grpc_server_method` is available in the context for the entire RPC call handling. 
+`grpc_server_status` is only available around metrics recorded at the end of the request.
 
 ### Default views
 

--- a/stats/gRPC.md
+++ b/stats/gRPC.md
@@ -44,8 +44,8 @@ All client metrics should be tagged with the following.
 
 | Tag name           | Description                                                                                                      |
 |--------------------|------------------------------------------------------------------------------------------------------------------|
-| grpc.client_method | Full gRPC method name, including package, service and method, e.g. google.bigtable.v2.Bigtable/CheckAndMutateRow |
-| grpc.client_status | gRPC server status code received, e.g. OK, CANCELLED, DEADLINE_EXCEEDED                                          |
+| grpc_client_method | Full gRPC method name, including package, service and method, e.g. google.bigtable.v2.Bigtable/CheckAndMutateRow |
+| grpc_client_status | gRPC server status code received, e.g. OK, CANCELLED, DEADLINE_EXCEEDED                                          |
 
 ### Default views
 
@@ -86,8 +86,8 @@ All server metrics should be tagged with the following.
 
 | Tag name           | Description                                                                                                    |
 |--------------------|----------------------------------------------------------------------------------------------------------------|
-| grpc.server_method | Full gRPC method name, including package, service and method, e.g. com.exampleapi.v4.BookshelfService/Checkout |
-| grpc.server_status | gRPC server status code returned, e.g. OK, CANCELLED, DEADLINE_EXCEEDED                                        |
+| grpc_server_method | Full gRPC method name, including package, service and method, e.g. com.exampleapi.v4.BookshelfService/Checkout |
+| grpc_server_status | gRPC server status code returned, e.g. OK, CANCELLED, DEADLINE_EXCEEDED                                        |
 
 `grpc.server_method` is available in the context for the entire RPC call handling. 
 `grpc.server_status` is only available around metrics recorded at the end of the request.


### PR DESCRIPTION
This is because the main stats backends that we currently support Prometheus and Stackdriver they do not support '.':
https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels

Unfortunately I cannot find the SD requirements, but I manually tested and '.' is not accepted.

This does not mean for the moment that we force this rule for all the tags, but we do it here for the most common tags at least. We will re-evaluate what is the best approach for sanitization later.