### PR TITLE
Revert "Allow any unicode characters in the TagValue #71"

### DIFF
--- a/tags/TagContext.md
+++ b/tags/TagContext.md
@@ -20,8 +20,8 @@ A string or string wrapper, with some restrictions:
 
 ## TagValue
 
-A TagValue can be any unicode string whose size when encoded in UTF-8
-is less than 256 bytes. An empty value is allowed.
+A string or string wrapper with the same restrictions as `TagKey`, except that it
+is allowed to be empty.
 
 ## Serialization
 


### PR DESCRIPTION
Reverts https://github.com/census-instrumentation/opencensus-specs/pull/71.

Based on our meeting today, we need more discussions on supporting Unicode.