### PR TITLE
Temporary remove Max aggregation and add details how to convert Aggregation into Metrics.

### DIFF
--- a/stats/DataAggregation.md
+++ b/stats/DataAggregation.md
@@ -11,8 +11,6 @@ An Aggregation describes how data collected is aggregated.
 The library SHOULD provide support for multiple types of Aggregations:
 * `Count`: counts the number of measurements recorded.
 * `Sum`: indicates that data collected and aggregated with this `Aggregation` will be summed up.
-* `Max`: indicates that data collected and aggregated with this `Aggregation` will calculate the 
-maximum value recorded.
 * `LastValue`: indicates that data collected and aggregated with this `Aggregation` will 
 represent the last recorded value. This is useful to support Gauges.
 * `Distribution`: indicates that the desired `Aggregation` is a histogram distribution. A
@@ -31,7 +29,7 @@ within the library.
 * `columns`: an array of tag keys. These values associated with tags of this name form the basis 
 by which individual stats will be aggregated (one aggregation per unique tag value). If none are 
 provided, then all data is recorded in a single aggregation.
-* `aggregation`: `Distribution`, `Count`, `Sum`, `LastValue`, `Max`.
+* `aggregation`: `Distribution`, `Count`, `Sum`, `LastValue`.
 
 Implementations SHOULD define a View data type, constructed from the parameters above. Views MAY 
 have getters for retrieving all of the information used in View definition. Once created, View 

--- a/stats/Export.md
+++ b/stats/Export.md
@@ -13,7 +13,6 @@ The library SHOULD provide support for multiple types of Aggregations:
 * `CountData`: data generated for a `Count` aggregation.
 * `SumDataDouble` and `SumDataInt64`: data generated for a `Sum` aggregation based on the `Measure`
 type.
-* `MaxData`: data generated for a `Max` aggregation.
 * `LastValueDataDouble` and `LastValueDataInt64`: data generated for a `LastValue` aggregation based 
 on the `Measure` type.
 * `DistributionData`: data generated for a `Distribution` aggregation.
@@ -28,3 +27,14 @@ parameter from the `View` and the aggregated data associated with those `columns
 * `end_time`: a timestamp, describing the end time of the current stats snapshot.
 
 The library SHOULD provide a means of retrieving the ViewData for any registered view in the system.
+
+### Aggregation to Metrics
+
+| Aggregation  | Measure Type | Metric Type  | Value Type   |
+|--------------|--------------|--------------|--------------|
+| Count        | Any          | CUMULATIVE   | INT64        |
+| Sum          | Double       | CUMULATIVE   | DOUBLE       |
+| Sum          | Int64        | CUMULATIVE   | INT64        |
+| LastValue    | Double       | GAUGE        | DOUBLE       |
+| LastValue    | Int64        | GAUGE        | INT64        |
+| Distribution | Int64        | CUMULATIVE   | DISTRIBUTION |

--- a/stats/Export.md
+++ b/stats/Export.md
@@ -28,7 +28,7 @@ parameter from the `View` and the aggregated data associated with those `columns
 
 The library SHOULD provide a means of retrieving the ViewData for any registered view in the system.
 
-### Aggregation to Metrics
+### Aggregation to Metric
 
 | Aggregation  | Measure Type    | Metric Type  | Value Type   | Unit               |
 |--------------|-----------------|--------------|--------------|--------------------|

--- a/stats/Export.md
+++ b/stats/Export.md
@@ -30,11 +30,13 @@ The library SHOULD provide a means of retrieving the ViewData for any registered
 
 ### Aggregation to Metrics
 
-| Aggregation  | Measure Type | Metric Type  | Value Type   |
-|--------------|--------------|--------------|--------------|
-| Count        | Any          | CUMULATIVE   | INT64        |
-| Sum          | Double       | CUMULATIVE   | DOUBLE       |
-| Sum          | Int64        | CUMULATIVE   | INT64        |
-| LastValue    | Double       | GAUGE        | DOUBLE       |
-| LastValue    | Int64        | GAUGE        | INT64        |
-| Distribution | Int64        | CUMULATIVE   | DISTRIBUTION |
+| Aggregation  | Measure Type | Metric Type  | Value Type   | Unit               |
+|--------------|--------------|--------------|--------------|--------------------|
+| Count        | Any          | CUMULATIVE   | INT64        | Dimensionless Unit |
+| Sum          | Double       | CUMULATIVE   | DOUBLE       | Measure Unit       |
+| Sum          | Int64        | CUMULATIVE   | INT64        | Measure Unit       |
+| LastValue    | Double       | GAUGE        | DOUBLE       | Measure Unit       |
+| LastValue    | Int64        | GAUGE        | INT64        | Measure Unit       |
+| Distribution | Any          | CUMULATIVE   | DISTRIBUTION | Measure Unit       |
+
+Dimensionless Unit can be represented as "1".

--- a/stats/Export.md
+++ b/stats/Export.md
@@ -30,13 +30,13 @@ The library SHOULD provide a means of retrieving the ViewData for any registered
 
 ### Aggregation to Metrics
 
-| Aggregation  | Measure Type | Metric Type  | Value Type   | Unit               |
-|--------------|--------------|--------------|--------------|--------------------|
-| Count        | Any          | CUMULATIVE   | INT64        | Dimensionless Unit |
-| Sum          | Double       | CUMULATIVE   | DOUBLE       | Measure Unit       |
-| Sum          | Int64        | CUMULATIVE   | INT64        | Measure Unit       |
-| LastValue    | Double       | GAUGE        | DOUBLE       | Measure Unit       |
-| LastValue    | Int64        | GAUGE        | INT64        | Measure Unit       |
-| Distribution | Any          | CUMULATIVE   | DISTRIBUTION | Measure Unit       |
+| Aggregation  | Measure Type    | Metric Type  | Value Type   | Unit               |
+|--------------|-----------------|--------------|--------------|--------------------|
+| Count        | Int64 or Double | CUMULATIVE   | INT64        | Dimensionless Unit |
+| Sum          | Double          | CUMULATIVE   | DOUBLE       | Measure Unit       |
+| Sum          | Int64           | CUMULATIVE   | INT64        | Measure Unit       |
+| LastValue    | Double          | GAUGE        | DOUBLE       | Measure Unit       |
+| LastValue    | Int64           | GAUGE        | INT64        | Measure Unit       |
+| Distribution | Int64 or Double | CUMULATIVE   | DISTRIBUTION | Measure Unit       |
 
 Dimensionless Unit can be represented as "1".


### PR DESCRIPTION
For the moment we do not have a clear use for Max aggregation but we are happy to add it when necessary.

Add a table that explain how to convert stats aggregations to metrics.