### PR TITLE
Add prefix to all resource properties.

### DIFF
--- a/utils/MonitoredResource.md
+++ b/utils/MonitoredResource.md
@@ -7,20 +7,20 @@ detect these resources.
 
 * GCP_GCE_INSTANCE
   * gcp_account: The GCP account number for the instance.
-  * instance_id: The numeric VM instance identifier assigned by GCE.
-  * zone: The GCE zone in which the VM is running.
+  * gcp_instance_id: The numeric VM instance identifier assigned by GCE.
+  * gcp_zone: The GCE zone in which the VM is running.
 * GCP_GKE_CONTAINER
   * gcp_account: The GCP account number for the instance.
-  * cluster_name: The name for the cluster the container is running in.
-  * namespace_id: The identifier for the cluster namespace the container is running in.
-  * instance_id: The identifier for the GCE instance the container is running in.
-  * pod_id: The identifier for the pod the container is running in.
-  * container_name: The name of the container.
-  * zone: The zone for the instance.
+  * gcp_cluster_name: The name for the cluster the container is running in.
+  * gcp_namespace_id: The identifier for the cluster namespace the container is running in.
+  * gcp_instance_id: The identifier for the GCE instance the container is running in.
+  * gcp_pod_id: The identifier for the pod the container is running in.
+  * gcp_container_name: The name of the container.
+  * gcp_zone: The zone for the instance.
 * AWS_EC2_INSTANCE
   * aws_account: The AWS account number for the instance.
-  * instance_id: The VM instance identifier assigned by AWS.
-  * region: The AWS region for the cluster.
+  * aws_instance_id: The VM instance identifier assigned by AWS.
+  * aws_region: The AWS region for the cluster.
   
 ## How to automatically detect the Monitored Resource
 
@@ -37,15 +37,15 @@ implemented libraries, e.g. [see this][GCPMetadataJavaExmple] for Java GCP metad
 
 If the environment variable `KUBERNETES_SERVICE_HOST` is set.
 
-| Property Name  | Environment Variable | Metadata Request                 |
-|----------------|----------------------|----------------------------------|
-| gcp_account    |                      | project/project-id               |
-| cluster_name   |                      | instance/attributes/cluster-name |
-| namespace_id   | NAMESPACE            |                                  |
-| instance_id    |                      | instance/id                      |
-| pod_id         | HOSTNAME             |                                  |
-| container_name | CONTAINER_NAME       |                                  |
-| zone           |                      | instance/zone                    |
+| Property Name      | Environment Variable | Metadata Request                 |
+|--------------------|----------------------|----------------------------------|
+| gcp_account        |                      | project/project-id               |
+| gcp_cluster_name   |                      | instance/attributes/cluster-name |
+| gcp_namespace_id   | NAMESPACE            |                                  |
+| gcp_instance_id    |                      | instance/id                      |
+| gcp_pod_id         | HOSTNAME             |                                  |
+| gcp_container_name | CONTAINER_NAME       |                                  |
+| gcp_zone           |                      | instance/zone                    |
 
 The namespace_id and container_name are optional. We cannot get their value from environment
 variables unless k8s users expose them via the [Downward API][DownwardAPI]. See k8s
@@ -55,22 +55,22 @@ variables unless k8s users expose them via the [Downward API][DownwardAPI]. See 
 
 If the GCP metadata service returns a value for "instance/id" and not GCP_GKE_CONTAINER.
 
-| Property Name  | Environment Variable | Metadata Request   |
-|----------------|----------------------|--------------------|
-| gcp_account    |                      | project/project-id |
-| instance_id    |                      | instance/id        |
-| zone           |                      | instance/zone      |
+| Property Name      | Environment Variable | Metadata Request   |
+|--------------------|----------------------|--------------------|
+| gcp_account        |                      | project/project-id |
+| gcp_instance_id    |                      | instance/id        |
+| gcp_zone           |                      | instance/zone      |
 
 ### AWS_EC2_INSTANCE
  
 If the AWS metadata service returns a valid document for
 "instance-identity/document".
 
-| Property Name  | Environment Variable | Metadata Request           |
-|----------------|----------------------|----------------------------|
-| aws_account    |                      | instance-identity/document |
-| instance_id    |                      | instance-identity/document |
-| region         |                      | instance-identity/document |
+| Property Name      | Environment Variable | Metadata Request           |
+|--------------------|----------------------|----------------------------|
+| aws_account        |                      | instance-identity/document |
+| aws_instance_id    |                      | instance-identity/document |
+| aws_region         |                      | instance-identity/document |
 
 The value return by the `instance-identity/document` metadata request is a document described 
 [here][AWSMetadataIdentityDocument].


### PR DESCRIPTION
Closes https://github.com/census-instrumentation/opencensus-specs/issues/105.

This makes the property names more clear. However, now the property names don't match with the Stackdriver definitions (https://cloud.google.com/monitoring/api/resources#tag_aws_ec2_instance).