### PR TITLE
Stats: Update the Java code snippet on recording Exemplar.

### DIFF
--- a/stats/Record.md
+++ b/stats/Record.md
@@ -76,10 +76,10 @@ measurementMap.record();  // reads context from thread-local.
 // Another example on recording against sampled SpanContext.
 SpanContext spanContext = tracer.getCurrentSpan().getContext();
 if (spanContext.getTraceOptions().isSampled()) {
-  Map<String, String> map = new HashMap<>();
   // Client code needs to take care of encoding.
-  map.put("TraceId", encode(spanContext.getTraceId()));
-  map.put("SpanId", encode(spanContext.getSpanId()));
-  measurementMap.record(tagContext, map);
+  // 'Attachment' is the string representation of the contextual information of an exemplar.
+  measurementMap.putAttachment("TraceId", encode(spanContext.getTraceId()));
+  measurementMap.putAttachment("SpanId", encode(spanContext.getSpanId()));
+  measurementMap.record(tagContext);
 }
 ```

--- a/stats/Record.md
+++ b/stats/Record.md
@@ -45,7 +45,7 @@ measure name instead of the `Measure`.
 Implementations MAY define a `MeasurementMap` which describes a set of data points to be collected
 for a set of Measures. Adding this functionality may improve the efficiency of the record usage API.
 Additionally, when recording Measurements, `MeasurementMap` should optionally take a map of string 
-key-value pairs to record an exemplar. The string map is called attachments and represents the 
+key-value pairs to record an exemplar. The string map is called `attachments` and represents the 
 contextual information of an exemplar, for example trace id, span id or dropped labels.
 
 ## Recording Stats

--- a/stats/Record.md
+++ b/stats/Record.md
@@ -45,7 +45,8 @@ measure name instead of the `Measure`.
 Implementations MAY define a `MeasurementMap` which describes a set of data points to be collected
 for a set of Measures. Adding this functionality may improve the efficiency of the record usage API.
 Additionally, when recording Measurements, `MeasurementMap` should optionally take a map of string 
-key-value pairs to record an exemplar.
+key-value pairs to record an exemplar. The string map is called attachments and represents the 
+contextual information of an exemplar, for example trace id, span id or dropped labels.
 
 ## Recording Stats
 


### PR DESCRIPTION
The idea is essentially the same. The builder-style API (`putAttachment()`) should make the API easier to use, compared to overloading and having multiple versions of `record()`.

This matches the current API design in Java (https://github.com/census-instrumentation/opencensus-java/pull/1285).