### PR TITLE
Tracing: Add specifications on default TraceParams.

### DIFF
--- a/trace/TraceConfig.md
+++ b/trace/TraceConfig.md
@@ -14,7 +14,7 @@ is a [Probability](Sampling.md) sampler with the probability set to `1/10000`.
 * Default max number of `Message Event`s per `Span` - used when creating a Span if no specific limit 
 on `Message Event`s is given. The default limit is 128.
 * Default max number of `Link`s per `Span` - used when creating a Span if no specific limit on 
-`Link`s is given. The default limit is 128.
+`Link`s is given. The default limit is 32.
 
 ## API Summary
 * Permanently update the active TraceParams.

--- a/trace/TraceConfig.md
+++ b/trace/TraceConfig.md
@@ -7,8 +7,14 @@ sampler, maximum events to be kept, etc.
 Represents the set of parameters that users can control 
 * Default `Sampler` - used when creating a Span if no specific sampler is given. The default sampler
 is a [Probability](Sampling.md) sampler with the probability set to `1/10000`.
-
-TODO(bdrutu): Define the rest of the params.
+* Default max number of `Attribute`s per `Span` - used when creating a Span if no specific limit on 
+`Attribute`s is given. The default limit is 32.
+* Default max number of `Annotation`s per `Span` - used when creating a Span if no specific limit on 
+`Annotation`s is given. The default limit is 32.
+* Default max number of `Message Event`s per `Span` - used when creating a Span if no specific limit 
+on `Message Event`s is given. The default limit is 128.
+* Default max number of `Link`s per `Span` - used when creating a Span if no specific limit on 
+`Link`s is given. The default limit is 128.
 
 ## API Summary
 * Permanently update the active TraceParams.


### PR DESCRIPTION
Related to https://github.com/census-instrumentation/opencensus-specs/issues/138.

/cc @bogdandrutu 