### PR TITLE
add doc on zipkin exporter for converting oc spans

### DIFF
--- a/trace/exporter/zipkin.md
+++ b/trace/exporter/zipkin.md
@@ -1,0 +1,69 @@
+# Zipkin Reporter
+
+## OC Span to Zipkin JSON
+
+### Annotations
+
+An annotation in Zipkin data model is a timestamp and string value. OpenCensus annotations must be converted to string representations of the annotation or message event.
+
+OpenCensus annotation is a timestamp and either a description and attributes:
+
+```
+{"time": integer,
+  "annotation": {"description": string, 
+                 "attributes": {string: attribute_value}}}
+``` 
+
+or a message event:
+
+```
+{"time": integer,
+  "message_event": {"type": string, 
+                    "id": integer,
+                    "compressed_size": integer,
+                    "uncompressed_size": integer}}
+``` 
+
+In this format the Zipkin annotation looks like:
+                 
+```
+{"timestamp": integer,
+ "value": string}
+```
+
+To not lose information the attributes of an OpenCensus annotation are encoded into a string of `key=value` pairs separated by commas and appended to the description string followed by the string `Attributes:`.
+
+For example:
+
+```
+{"time": 12345,
+  "annotation": {"description": "the annotation description", 
+                 "attributes": {"key-1": "value-1",
+                                "key-2": "value-2"}}}
+``` 
+
+Becomes:
+
+```
+{"timestamp": 12345,
+ "value": "the annotation description Attributes:{key-1=value-1, key-2=value-2}"}
+```
+
+For a message event each element is similarly encoded into a `key=value` pair separated by a comma and appended to the string `MessageEvent:`.
+
+For example:
+
+```
+{"time": 67890,
+  "message_event": {"type": "SENT", 
+                    "id": 5,
+                    "compressed_size": 25,
+                    "uncompressed_size": 38}}
+``` 
+
+Becomes:
+
+```
+{"timestamp": 67890,
+ "value": "MessageEvent:{type=Sent, id=5, compressed_size=25, uncompressed_size=38}"}
+```


### PR DESCRIPTION
This currently only describes the annotations but I can expand to cover the rest of a span, either in this same PR or this can be merged and I'll send another to fill out the rest.

I'm also curious if zipkin wouldn't be better served if message events were included twice. Once as is described in this document to include the id and sizes and an additional time with just the type, but in zipkin's form.

From the example in the document:

```
{"time": 67890,
  "message_event": {"type": "SENT", 
                    "id": 5,
                    "compressed_size": 25,
                    "uncompressed_size": 38}}
``` 

Would result in two annotations, one with value of just "ss" or "cs" for "server sent" or "client sent" (problem is I don't know how it would know if it is the server or client...):

```
{"timestamp": 67890,
 "value": "ss"}

{"timestamp": 67890,
 "value": "MessageEvent:{type=Sent, id=5, compressed_size=25, uncompressed_size=38}"}
```