### PR TITLE
Use shorter key names for log correlation (issue #195).

### DIFF
--- a/trace/LogCorrelation.md
+++ b/trace/LogCorrelation.md
@@ -54,5 +54,5 @@ and format the sampling decision as "true" or "false".
 
 Some logging frameworks allow the insertion of arbitrary key-value pairs into log entries.  When
 a log correlation implementation inserts tracing data by that method, the key names should be
-"opencensusTraceId", "opencensusSpanId", and "opencensusTraceSampled" by default.  The log
-correlation implementation may allow the user to override the tracing data key names.
+"traceId", "spanId", and "traceSampled" by default.  The log correlation implementation may allow
+the user to override the tracing data key names.


### PR DESCRIPTION
This commit removes the "openCensus" prefix from all key names in the log
correlation spec.  The shorter key names are simpler and could improve
performance when the keys are included in the logs.

/cc @yurishkuro @rakyll @ramonza @SergeyKanzhelev