### PR TITLE
Implementations should provide a way to avoid undesirable propagation

### DIFF
--- a/trace/HTTP.md
+++ b/trace/HTTP.md
@@ -4,7 +4,7 @@ This document explains tracing of HTTP requests with OpenCensus.
 
 ## Spans
 
-Implementations MUST create a span for outgoing requests at the client and a span for incoming 
+Implementations MUST create a span for outgoing requests at the client and a span for incoming
 requests at the server.
 
 Span name is formatted as:
@@ -29,24 +29,28 @@ incoming requests should be a span kind of SERVER.
 
 Propagation is how SpanContext is transmitted on the wire in an HTTP request.
 
-Implementations MUST allow users to set their own propagation format and MUST provide an 
+Implementations MUST allow users to set their own propagation format and MUST provide an
 implementation for B3 at least.
+
+Implementations should provide a way to avoid propagating SpanContext altogether from both
+inbound requests and on outbound requests while still generating spans as usual
+around the inbound/outbound request.
 
 If user doesn't set any propagation methods explicitly, B3 is used.
 
-The propagation method SHOULD modify a request object to insert a SpanContext or SHOULD be able 
+The propagation method SHOULD modify a request object to insert a SpanContext or SHOULD be able
 to extract a SpanContext from a request object.
 
 ## Status
 
-Implementations MUST set status if HTTP request or response is not successful (e.g. not 2xx). In 
-redirection case, if the client doesn't have autoredirection support, request should be 
+Implementations MUST set status if HTTP request or response is not successful (e.g. not 2xx). In
+redirection case, if the client doesn't have autoredirection support, request should be
 considered successful.
 
-Set status code to UNKNOWN (2) if the reason cannot be inferred at the callsite or from the HTTP 
+Set status code to UNKNOWN (2) if the reason cannot be inferred at the callsite or from the HTTP
 status code.
 
-Don't set the status message if the reason can be inferred at the callsite of from the HTTP 
+Don't set the status message if the reason can be inferred at the callsite of from the HTTP
 status code.
 
 ### Mapping from HTTP status codes to Trace status codes
@@ -103,7 +107,7 @@ All attributes are optional.
 | "http.user_agent"         | Request user-agent          | "HTTPClient/1.2"                |
 | "http.status_code"        | Response status code        | 200                             |
 
-Exporters should always export the collected attributes. Exporters should map the collected 
+Exporters should always export the collected attributes. Exporters should map the collected
 attributes to backend's known attributes/labels.
 
 The following table summarizes how OpenCensus attributes maps to the

--- a/trace/gRPC.md
+++ b/trace/gRPC.md
@@ -4,7 +4,7 @@ This document explains tracing of gRPC requests with OpenCensus.
 
 ## Spans
 
-Implementations MUST create a span, when the gRPC call starts, for the client and a span for the 
+Implementations MUST create a span, when the gRPC call starts, for the client and a span for the
 server.
 
 Span name is formatted as (also known as full gRPC method name):
@@ -25,13 +25,17 @@ For backends that does not support Span.Kind, the exported span names can be pre
 
 Propagation is how SpanContext is transmitted on the wire in an gRPC request.
 
-The propagation MUST inject a SpanContext (as a gRPC metadata `grpc-trace-bin`) and MUST extract 
+The propagation MUST inject a SpanContext (as a gRPC metadata `grpc-trace-bin`) and MUST extract
 a SpanContext from the gRPC metadata. The serialization format is defined
 [here](../encodings/BinaryEncoding.md).
 
+Implementations should provide a way to avoid propagating SpanContext altogether from both
+inbound requests and on outbound requests while still generating spans as usual
+around the inbound/outbound request.
+
 ## Status
 
-Implementations MUST set status which should be the same as the gRPC client/server status. The 
+Implementations MUST set status which should be the same as the gRPC client/server status. The
 mapping between gRPC canonical codes and OpenCensus status codes can be found
 [here](https://github.com/grpc/grpc-go/blob/master/codes/codes.go).
 
@@ -49,7 +53,7 @@ In the lifetime of a gRPC stream, the following message events SHOULD be created
 -> [time], MessageEventTypeRecv, MessageId, UncompressedByteSize, CompressedByteSize
 ```
 
-The `MessageId` must be calculated as two different counters starting from `1` one for sent 
-messages and one for received message. This way we guarantee that the values will be consistent 
-between different implementations. In case of unary calls only one sent and one received message 
+The `MessageId` must be calculated as two different counters starting from `1` one for sent
+messages and one for received message. This way we guarantee that the values will be consistent
+between different implementations. In case of unary calls only one sent and one received message
 will be recorded for both client and server spans.


### PR DESCRIPTION
Sometimes it is not desirable to propagate tracing metadata at all.
For example, if you're calling an external API.